### PR TITLE
Add github pages link to the README markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # CSE 110 Lab 3 - Justin Butera
 
-Link to published site: TODO
+Link to published site: [https://jbutera94.github.io/fa21-cse110-lab3/](https://jbutera94.github.io/fa21-cse110-lab3/)


### PR DESCRIPTION
This branch adds the GitHub pages link of my lab 3 website to the `README.md` file. Closes #8.